### PR TITLE
Closing `TcpListeners` in runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "fortanix-vme-abi"
 version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#c20372154cc363498df268cec7cd01e015575b35"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#4c77b210335d8fdd3422a1ef922244844d22d6ea"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -113,6 +113,11 @@ impl FromRawFd for OwnedFd {
 impl Drop for OwnedFd {
     #[inline]
     fn drop(&mut self) {
+        // We can't handle errors properly here and ignore them. Worst case the runner keeps listening on the TCP socket. The
+        // enclave won't ever accept a new connection, but the port may not be released.
+        #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "fortanixvme"))]
+        let _ = crate::sys::net::close_listener(self.fd.clone());
+
         unsafe {
             // Note that errors are ignored when closing a file descriptor. The
             // reason for this is that if an error occurs we don't actually know if

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -112,6 +112,19 @@ impl Client {
         }
     }
 
+    pub fn close_listener_socket(&mut self, enclave_port: u32) -> Result<(), io::Error> {
+        let close = Request::Close {
+            enclave_port
+        };
+        self.send(&close)?;
+
+        if let Response::Closed = self.receive()? {
+            Ok(())
+        } else {
+            Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
+        }
+    }
+
     fn send(&mut self, req: &Request) -> Result<(), io::Error> {
         let req: Vec<u8> = serde_cbor::ser::to_vec(req).map_err(|_e| io::Error::new(ErrorKind::Other, "serialization failed"))?;
         self.stream.write(req.as_slice())?;


### PR DESCRIPTION
When a Nitro enclave closes a TcpListener, sockets in the runner need to be cleaned up as well. This PR introduces the required changes in the standard library.