### PR TITLE
Return local and peer addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "fortanix-vme-abi"
 version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#cce2e1108f672c8004d55bae24f5ad97a7f34145"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#54678e0074abcb739474aa57859acf688dd1fe9a"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -63,14 +63,14 @@ impl Client {
         })
     }
 
-    pub fn open_proxy_connection(&mut self, addr: String) -> Result<(VsockStream<Fortanixvme>, Addr), io::Error> {
+    pub fn open_proxy_connection(&mut self, addr: String) -> Result<(VsockStream<Fortanixvme>, Addr, Addr), io::Error> {
         let connect = Request::Connect {
             addr
         };
         self.send(&connect)?;
-        if let Response::Connected { proxy_port, peer } = self.receive()? {
+        if let Response::Connected { proxy_port, local, peer } = self.receive()? {
             let proxy = Self::connect(proxy_port)?;
-            Ok((proxy, peer))
+            Ok((proxy, local, peer))
         } else {
             Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
         }
@@ -99,14 +99,14 @@ impl Client {
         }
     }
 
-    pub fn accept(&mut self, fd: i32) -> Result<(Addr, u32), io::Error> {
+    pub fn accept(&mut self, fd: i32) -> Result<(Addr, Addr, u32), io::Error> {
         let accept = Request::Accept {
             fd
         };
         self.send(&accept)?;
 
-        if let Response::IncomingConnection { peer, proxy_port } = self.receive()? {
-            Ok((peer, proxy_port))
+        if let Response::IncomingConnection { local, peer, proxy_port } = self.receive()? {
+            Ok((local, peer, proxy_port))
         } else {
             Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
         }

--- a/library/std/src/sys/unix/fortanixvme/net.rs
+++ b/library/std/src/sys/unix/fortanixvme/net.rs
@@ -428,6 +428,11 @@ impl TcpStream {
         }
     }
 
+    /// Returns the local address.
+    ///
+    /// # Warning
+    ///
+    /// There is no guarantee that the `TcpStream` actually communicates from the `SocketAddr`.
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         if let Some(local) = &self.inner.local {
             Ok(addr_to_sockaddr(local.clone()))

--- a/library/std/src/sys/unix/fortanixvme/net.rs
+++ b/library/std/src/sys/unix/fortanixvme/net.rs
@@ -518,6 +518,9 @@ impl TcpListener {
         // When `accept` returns, the runner has accepted a new connection for peer. It will try
         // to connect to the enclave from `runner_port`
         let (peer, runner_port) = runner.accept(listener_info.fd_runner)?;
+        // Small optimization: No need to keep the connection to the runner while we wait for an
+        // incoming vsock connection in step 3
+        drop(runner);
 
         // (2) Store a mapping `runner_port` -> `peer`, where `runner_port` is the port the runner
         // will connect to the enclave in (3). `peer` is the address of the


### PR DESCRIPTION
This PR performs the following tasks:
* Adds support to return the local address a `TcpListener` is bound to
* Adds support to return the peer address of `TcpStream`. For this to work the `Socket` implementation has been modified to record this information. There is a corner case where the peer address is not kept in the `Socket`: When a `Socket` is created directly from a raw file descriptor. In such cases an `AddrNotAvailable` error is returned. Future work will request the runner for this information.
* Small optimization where the connection to the runner is dropped before it waits for an incoming connection from the runner.