### PR TITLE
Enable reusing fds

### DIFF
--- a/library/std/src/sys/unix/fortanixvme/net.rs
+++ b/library/std/src/sys/unix/fortanixvme/net.rs
@@ -134,7 +134,7 @@ fn store_listener_info(info: FdInfo) {
 }
 
 fn get_listener_info(local_fd: RawFd) -> Option<FdInfo> {
-    listener_info().lock().unwrap().iter().find_map(|info| if local_fd == info.fd_enclave {
+    listener_info().lock().unwrap().iter().rev().find_map(|info| if local_fd == info.fd_enclave {
             Some(info.to_owned())
         } else {
             None


### PR DESCRIPTION
Currently the standard library stores a list of `listener_info`. This list is not cleaned up yet when a socket is closed. This memory leak is a problem that will be addressed in another PR. This PR ensures that when the kernel reuses a file descriptor value for a listener, always the right information is retrieved from the list of `listerner_info`. It does so by ensuring that it has FIFO behavior.