### PR TITLE
[PLAT-345] Refactor `TcpListeners`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,6 @@ dependencies = [
 [[package]]
 name = "fortanix-vme-abi"
 version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#54678e0074abcb739474aa57859acf688dd1fe9a"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -5643,7 +5642,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "vsock"
 version = "0.2.4"
-source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#a090e2a1268f087bbef0c0b9785bab94c394f3dc"
+source = "git+https://github.com/fortanix/vsock-rs.git?branch=raoul/sock_addr_from_raw#d42071c5a4651200e7e4dd4dcdfd1bf43e0bc852"
 dependencies = [
  "compiler_builtins",
  "getrandom 0.2.3",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -42,10 +42,10 @@ dlmalloc = { version = "0.2.1", features = ['rustc-dep-of-std'] }
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-unknown-linux-fortanixvme.dependencies]
-fortanix-vme-abi = { git = "https://github.com/fortanix/rust-sgx.git", branch = "master", default-features = false, features = ['rustc-dep-of-std'] }
+fortanix-vme-abi = { git = "https://github.com/fortanix/rust-sgx.git", branch = "raoul/PLAT-345-refactor_tcp_listeners", default-features = false, features = ['rustc-dep-of-std'] }
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master", default-features = false, features = ["derive", "rustc-dep-of-std"] }
 serde_cbor = { git = "https://github.com/fortanix/cbor.git", branch = "fortanixvme", default-features = false, features = ["alloc", "rustc-dep-of-std"] }
-vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme", default-features = false, features = ['rustc-dep-of-std', 'random_port'] }
+vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "raoul/sock_addr_from_raw", default-features = false, features = ['rustc-dep-of-std', 'random_port'] }
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
 hermit-abi = { version = "0.1.19", features = ['rustc-dep-of-std'] }

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -77,9 +77,9 @@ impl Client {
     }
 
     /// Bind a TCP socket in the parent VM to the specified address. Returns the `VsockListener`
-    /// listening for incoming connections forwarded by the parent VM and the TCP port the runner
+    /// listening for incoming connections forwarded by the parent VM and the local address the runner
     /// is listening on
-    pub fn bind_socket(&mut self, addr: String) -> Result<(VsockListener<Fortanixvme>, Addr, i32), io::Error> {
+    pub fn bind_socket(&mut self, addr: String) -> Result<(VsockListener<Fortanixvme>, Addr), io::Error> {
         // Start listener socket within enclave, waiting for incoming connections from enclave
         // runner
         let listener = VsockListener::bind_with_cid(vsock::VMADDR_CID_ANY)?;
@@ -92,16 +92,16 @@ impl Client {
             enclave_port,
         };
         self.send(&bind)?;
-        if let Response::Bound { local, fd } = self.receive()? {
-            Ok((listener, local, fd))
+        if let Response::Bound { local } = self.receive()? {
+            Ok((listener, local))
         } else {
             Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
         }
     }
 
-    pub fn accept(&mut self, fd: i32) -> Result<(Addr, Addr, u32), io::Error> {
+    pub fn accept(&mut self, vsock_port: u32) -> Result<(Addr, Addr, u32), io::Error> {
         let accept = Request::Accept {
-            fd
+            enclave_port: vsock_port
         };
         self.send(&accept)?;
 


### PR DESCRIPTION
[rust-sgx PR 361](https://github.com/fortanix/rust-sgx/pull/361) changes the enclave-runner interface. With `Sockets` storing the local address and the runner referencing open connections with their address, the `LISTENER_INFO` does no longer need to be stored as a static variable.