### PR TITLE
[PLAT-397] Refactor tcp listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "fortanix-vme-abi"
 version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#54678e0074abcb739474aa57859acf688dd1fe9a"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#c20372154cc363498df268cec7cd01e015575b35"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -5643,7 +5643,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "vsock"
 version = "0.2.4"
-source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#a090e2a1268f087bbef0c0b9785bab94c394f3dc"
+source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#8c0a6b75e9e0c8f2ce68ad4b7b6d6898852810e7"
 dependencies = [
  "compiler_builtins",
  "getrandom 0.2.3",

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -77,9 +77,9 @@ impl Client {
     }
 
     /// Bind a TCP socket in the parent VM to the specified address. Returns the `VsockListener`
-    /// listening for incoming connections forwarded by the parent VM and the TCP port the runner
+    /// listening for incoming connections forwarded by the parent VM and the local address the runner
     /// is listening on
-    pub fn bind_socket(&mut self, addr: String) -> Result<(VsockListener<Fortanixvme>, Addr, i32), io::Error> {
+    pub fn bind_socket(&mut self, addr: String) -> Result<(VsockListener<Fortanixvme>, Addr), io::Error> {
         // Start listener socket within enclave, waiting for incoming connections from enclave
         // runner
         let listener = VsockListener::bind_with_cid(vsock::VMADDR_CID_ANY)?;
@@ -92,16 +92,16 @@ impl Client {
             enclave_port,
         };
         self.send(&bind)?;
-        if let Response::Bound { local, fd } = self.receive()? {
-            Ok((listener, local, fd))
+        if let Response::Bound { local } = self.receive()? {
+            Ok((listener, local))
         } else {
             Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
         }
     }
 
-    pub fn accept(&mut self, fd: i32) -> Result<(Addr, Addr, u32), io::Error> {
+    pub fn accept(&mut self, vsock_port: u32) -> Result<(Addr, Addr, u32), io::Error> {
         let accept = Request::Accept {
-            fd
+            enclave_port: vsock_port
         };
         self.send(&accept)?;
 

--- a/library/std/src/sys/unix/fortanixvme/net.rs
+++ b/library/std/src/sys/unix/fortanixvme/net.rs
@@ -118,30 +118,6 @@ macro_rules! not_available {
 }
 
 #[derive(Clone, Debug)]
-struct FdInfo {
-    fd_enclave: RawFd,
-    local_addr: String,
-    fd_runner: i32,
-}
-static LISTENER_INFO: SyncOnceCell<Arc<Mutex<Vec<FdInfo>>>> = SyncOnceCell::new();
-
-fn listener_info() -> Arc<Mutex<Vec<FdInfo>>> {
-    LISTENER_INFO.get_or_init(|| Arc::new(Mutex::new(Vec::new()))).clone()
-}
-
-fn store_listener_info(info: FdInfo) {
-    listener_info().lock().unwrap().push(info);
-}
-
-fn get_listener_info(local_fd: RawFd) -> Option<FdInfo> {
-    listener_info().lock().unwrap().iter().rev().find_map(|info| if local_fd == info.fd_enclave {
-            Some(info.to_owned())
-        } else {
-            None
-        })
-}
-
-#[derive(Clone, Debug)]
 struct IncomingInfo {
     local: Addr,
     peer: Addr,
@@ -548,24 +524,10 @@ impl TcpListener {
     pub fn bind(addr: io::Result<&SocketAddr>) -> io::Result<TcpListener> {
         let addr = io_err_to_addr(addr)?;
         let mut runner = Client::new(fortanix_vme_abi::SERVER_PORT)?;
-        let (listener, local, fd) = runner.bind_socket(addr.clone())?;
-        // Store the fd the runner uses for the proxy TCP connection so we can tell it on which
-        // socket to accept new connections. It would be cleaner to keep such information in
-        // the TcpListener itself. Unfortunately, the code quite heavily relies on the fact
-        // that a `TcpListener` only has a `Socket` field, and a `Socket` is a wrapper around a
-        // `FileDesc`.
-        store_listener_info(FdInfo{
-            fd_enclave: listener.as_raw_fd(),
-            local_addr: addr.clone(),
-            fd_runner: fd
-        });
+        let (listener, local) = runner.bind_socket(addr)?;
         Ok(TcpListener {
             inner: Socket::from_listener(listener, local)
             })
-    }
-
-   fn listener_info(&self) -> Option<FdInfo> {
-        get_listener_info(self.inner.as_raw_fd())
     }
 
     pub fn socket(&self) -> &Socket {
@@ -576,15 +538,28 @@ impl TcpListener {
         self.inner
     }
 
-    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+    fn local_addr(&self) -> io::Result<Addr> {
         if let Some(local) = &self.inner.local {
-            Ok(addr_to_sockaddr(local.clone()))
+            Ok(local.clone())
         } else {
             // The socket doesn't have the local address as it was created though the
             // `FromInner<FileDesc>` trait
             // PLAT-367 Contact runner to locate the information
             Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Local address not recorded"))
         }
+    }
+
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        self.local_addr()
+            .map(|addr| addr_to_sockaddr(addr))
+    }
+
+    fn local_vsock_addr(&self) -> io::Result<VsockAddr> {
+        // It would've been cleaner to provide a way to turn `self.inner` into a `VsockListener`
+        // but we need to ensure that the `VsockListener` isn't dropped after the local address is
+        // retrieved.
+        let fd = self.inner.as_raw_fd();
+        VsockAddr::from_raw_fd::<Fortanixvme>(fd).map_err(|e| e.into())
     }
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
@@ -602,13 +577,12 @@ impl TcpListener {
          *     \    \-----  enclave ----/      / (3) Accept new incoming connection from runner
          *      \-------- proxy --------------/
          */
-        // (1) Tell the runner to accept an incoming connection on a specific socket.
-        let listener_info = self.listener_info()
-            .ok_or(io::Error::new(ErrorKind::Other, "Internal error"))?;
+        let local = self.local_vsock_addr()?;
+        // (1) Tell the runner to accept an incoming connection on a specific port.
         let mut runner = Client::new(fortanix_vme_abi::SERVER_PORT)?;
         // When `accept` returns, the runner has accepted a new connection for peer. It will try
         // to connect to the enclave from `runner_port`
-        let (local, peer, runner_port) = runner.accept(listener_info.fd_runner)?;
+        let (local, peer, runner_port) = runner.accept(local.port())?;
         // Small optimization: No need to keep the connection to the runner while we wait for an
         // incoming vsock connection in step 3
         drop(runner);


### PR DESCRIPTION
Enclaves use the file descriptors of connections in the runner as a handle. That is problematic as a list needs to be stored within the enclave to provide a mapping between connections within the enclave and their counterpart in the runner.
A better solution is to keep track of this list only within the runner. Connections can be referenced based on the `cid` and `port` they connect to and from.