### PR TITLE
[PLAT-367] connection info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "fortanix-vme-abi"
 version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#4c77b210335d8fdd3422a1ef922244844d22d6ea"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#87f9893fd7442c3e951d7599046e061c4f5d7b7a"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -5643,7 +5643,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "vsock"
 version = "0.2.4"
-source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#8c0a6b75e9e0c8f2ce68ad4b7b6d6898852810e7"
+source = "git+https://github.com/fortanix/vsock-rs.git?branch=fortanixvme#4628538042a0308d9a1f737da816666ab899dba4"
 dependencies = [
  "compiler_builtins",
  "getrandom 0.2.3",

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -42,6 +42,35 @@ impl Read for VsockStream<Fortanixvme> {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum ConnectionInfo {
+    Listener {
+        /// The local address the socket is bound to.
+        local: Addr,
+    },
+    Stream {
+        /// The local address the socket is bound to.
+        local: Addr,
+        /// The peer the socket is connected to.
+        peer: Addr,
+    },
+}
+
+impl ConnectionInfo {
+    pub(crate) fn new_stream_info(local: Addr, peer: Addr) -> Self {
+        ConnectionInfo::Stream {
+            local,
+            peer,
+        }
+    }
+
+    pub(crate) fn new_listener_info(local: Addr) -> Self {
+        ConnectionInfo::Listener {
+            local,
+        }
+    }
+}
+
 pub struct Client {
     stream: VsockStream<Fortanixvme>,
 }
@@ -126,31 +155,29 @@ impl Client {
         }
     }
 
-    pub fn info_listener(&mut self, enclave_port: u32) -> Result<Addr, io::Error> {
+    pub(crate) fn info_listener(&mut self, enclave_port: u32) -> Result<ConnectionInfo, io::Error> {
         let info = Request::Info {
             enclave_port,
             runner_port: None,
         };
         self.send(&info)?;
-
-        if let Response::Info { local, peer } = self.receive()? {
-            Ok(local)
+        if let Response::Info { local, peer: None } = self.receive()? {
+            Ok(ConnectionInfo::new_listener_info(local))
         } else {
-            Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
+            Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response"))
         }
     }
 
-    pub fn info_connection(&mut self, enclave_port: u32, runner_port: u32) -> Result<(Addr, Option<Addr>), io::Error> {
+    pub(crate) fn info_connection(&mut self, enclave_port: u32, runner_port: u32) -> Result<ConnectionInfo, io::Error> {
         let info = Request::Info {
             enclave_port,
             runner_port: Some(runner_port),
         };
         self.send(&info)?;
-
-        if let Response::Info { local, peer } = self.receive()? {
-            Ok((local, peer))
+        if let Response::Info { local, peer: Some(peer) } = self.receive()? {
+            Ok(ConnectionInfo::new_stream_info(local, peer))
         } else {
-            Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response received"))
+            Err(io::Error::new(ErrorKind::InvalidData, "Unexpected response"))
         }
     }
 

--- a/library/std/src/sys/unix/fortanixvme/net.rs
+++ b/library/std/src/sys/unix/fortanixvme/net.rs
@@ -558,10 +558,8 @@ impl TcpListener {
         if let Some(local) = &self.inner.local {
             Ok(local.clone())
         } else {
-            // The socket doesn't have the local address as it was created though the
-            // `FromInner<FileDesc>` trait
-            // PLAT-367 Contact runner to locate the information
-            Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Local address not recorded"))
+            let mut runner = Client::new(fortanix_vme_abi::SERVER_PORT)?;
+            runner.info_listener(self.local_vsock_addr()?.port())
         }
     }
 


### PR DESCRIPTION
When `TcpListener`s or `TcpStream`s are created from a `RawFd`, they lack information about local and/or peer ports used in the runner. When this information is requested, it needs to be fetched from the runner.