### PR TITLE
[PLAT-506] fortanixvme target

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2893,7 +2893,7 @@ where
         };
 
         let target = &cx.tcx().sess.target;
-        let target_env_gnu_like = matches!(&target.env[..], "gnu" | "musl");
+        let target_env_gnu_like = matches!(&target.env[..], "gnu" | "musl" | "fortanixvme");
         let win_x64_gnu = target.os == "windows" && target.arch == "x86_64" && target.env == "gnu";
         let linux_s390x_gnu_like =
             target.os == "linux" && target.arch == "s390x" && target_env_gnu_like;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -916,6 +916,7 @@ supported_targets! {
     ("aarch64-unknown-none-softfloat", aarch64_unknown_none_softfloat),
 
     ("x86_64-fortanix-unknown-sgx", x86_64_fortanix_unknown_sgx),
+    ("x86_64-unknown-linux-fortanixvme", x86_64_unknown_linux_fortanixvme),
 
     ("x86_64-unknown-uefi", x86_64_unknown_uefi),
     ("i686-unknown-uefi", i686_unknown_uefi),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_fortanixvme.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_fortanixvme.rs
@@ -1,0 +1,23 @@
+use crate::spec::{LinkerFlavor, SanitizerSet, StackProbeType, Target};
+
+pub fn target() -> Target {
+    let mut base = super::linux_musl_base::opts();
+    base.env = "fortanixvme".to_string();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-m64".to_string());
+    // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
+    base.stack_probes = StackProbeType::Call;
+    base.static_position_independent_executables = true;
+    base.supported_sanitizers =
+        SanitizerSet::ADDRESS | SanitizerSet::LEAK | SanitizerSet::MEMORY | SanitizerSet::THREAD;
+
+    Target {
+        llvm_target: "x86_64-unknown-linux-musl".to_string(),
+        pointer_width: 64,
+        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+            .to_string(),
+        arch: "x86_64".to_string(),
+        options: base,
+    }
+}

--- a/library/std/src/sys/unix/fortanixvme/client.rs
+++ b/library/std/src/sys/unix/fortanixvme/client.rs
@@ -1,5 +1,4 @@
 use crate::io::{self, ErrorKind, Read};
-use crate::sys::net::TcpStream;
 use fortanix_vme_abi::{Addr, Response, Request};
 use vsock::{self, Platform, VsockListener, VsockStream};
 

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -42,7 +42,7 @@ fn cc2ar(cc: &Path, target: TargetSelection) -> Option<PathBuf> {
         Some(PathBuf::from(ar))
     } else if target.contains("msvc") {
         None
-    } else if target.contains("musl") {
+    } else if target.contains("musl") || target.contains("fortanixvme") {
         Some(PathBuf::from("ar"))
     } else if target.contains("openbsd") {
         Some(PathBuf::from("ar"))
@@ -88,7 +88,7 @@ pub fn find(build: &mut Build) {
                 if target.contains("msvc") {
                     cfg.static_crt(true);
                 }
-                if target.contains("musl") {
+                if target.contains("musl") || target.contains("fortanixvme") {
                     cfg.static_flag(true);
                 }
             }
@@ -211,7 +211,7 @@ fn set_compiler(
             }
         }
 
-        t if t.contains("musl") => {
+        t if t.contains("musl") || t.contains("fortanixvme") => {
             if let Some(root) = build.musl_root(target) {
                 let guess = root.join("bin/musl-gcc");
                 if guess.exists() {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -176,6 +176,7 @@ fn copy_third_party_objects(
     }
 
     if target == "x86_64-fortanix-unknown-sgx"
+        || target == "x86_64-unknown-linux-fortanixvme"
         || builder.config.llvm_libunwind == LlvmLibunwind::InTree
             && (target.contains("linux") || target.contains("fuchsia"))
     {
@@ -204,7 +205,7 @@ fn copy_self_contained_objects(
     // to using gcc from a glibc-targeting toolchain for linking.
     // To do that we have to distribute musl startup objects as a part of Rust toolchain
     // and link with them manually in the self-contained mode.
-    if target.contains("musl") {
+    if target.contains("musl") || target.contains("fortanixvme") {
         let srcdir = builder.musl_libdir(target).unwrap_or_else(|| {
             panic!("Target {:?} does not have a \"musl-libdir\" key", target.triple)
         });
@@ -314,7 +315,7 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
 
         // Help the libc crate compile by assisting it in finding various
         // sysroot native libraries.
-        if target.contains("musl") {
+        if target.contains("musl") || target.contains("fortanixvme") {
             if let Some(p) = builder.musl_libdir(target) {
                 let root = format!("native={}", p.to_str().unwrap());
                 cargo.rustflag("-L").rustflag(&root);

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -116,6 +116,8 @@ v("musl-root", "target.x86_64-unknown-linux-musl.musl-root",
   "MUSL root installation directory (deprecated)")
 v("musl-root-x86_64", "target.x86_64-unknown-linux-musl.musl-root",
   "x86_64-unknown-linux-musl install directory")
+v("musl-root-fortanixvme", "target.x86_64-unknown-linux-fortanixvme.musl-root",
+  "x86_64-unknown-linux-fortanixvme install directory")
 v("musl-root-i586", "target.i586-unknown-linux-musl.musl-root",
   "i586-unknown-linux-musl install directory")
 v("musl-root-i686", "target.i686-unknown-linux-musl.musl-root",

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -179,7 +179,7 @@ pub fn check(build: &mut Build) {
         }
 
         // Make sure musl-root is valid
-        if target.contains("musl") {
+        if target.contains("musl") || target.contains("fortanixvme") {
             // If this is a native target (host is also musl) and no musl-root is given,
             // fall back to the system toolchain in /usr before giving up
             if build.musl_root(*target).is_none() && build.config.build == *target {


### PR DESCRIPTION
This PR adds built-in support for the fortanixvme target. This target is based on the `x86_64_unknown_linux_musl` target.
*warning* Building the actual target fails as the standard library still depends on the `serde_derive` crate. This will be resolved in an upcoming PR.