### PR TITLE
update insecure-time dependency

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -187,11 +187,13 @@ dependencies = [
 
 [[package]]
 name = "insecure-time"
-version = "0.2.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=master#e238cdf7505bc325b48b7e125a5f5db285e8609c"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334c4528aa2a5e5ee096336fbad1430724b424f13da69152cb619ed93de09b22"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+ "spin",
 ]
 
 [[package]]
@@ -425,6 +427,15 @@ dependencies = [
  "cmake",
  "compiler_builtins",
  "elf",
+ "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "spin"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+dependencies = [
  "rustc-std-workspace-core",
 ]
 

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -68,6 +68,3 @@ libc = { git = "https://github.com/fortanix/libc.git", branch = "fortanixvme-202
 serde = { git = "https://github.com/fortanix/serde.git", branch = "master" }
 serde_cbor = { git = "https://github.com/fortanix/cbor.git", branch = "fortanixvme" }
 vsock = { git = "https://github.com/fortanix/vsock-rs.git", branch = "fortanixvme-2023-05-07-alpha" }
-
-# x86_64-fortanix-unknown-sgx related patches
-insecure-time = { git = "https://github.com/fortanix/rust-sgx.git", branch = "master" }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -72,7 +72,7 @@ snmalloc-edp = { path = "../snmalloc-edp" , features = ['rustc-dep-of-std'], pub
 fortanix-sgx-abi = { version = "0.6.1", features = [
     'rustc-dep-of-std',
 ], public = true }
-insecure-time = { version = "0.2.0", default-features = false, features = ["rustc-dep-of-std"] }
+insecure-time = { version = "0.3", default-features = false, features = ["rustc-dep-of-std"] }
 
 [target.x86_64-unknown-linux-fortanixvme.dependencies]
 fortanix-vme-abi = { version = "0.1", default-features = false, features = [

--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -330,12 +330,12 @@ pub fn insecure_time() -> Duration {
             None
         };
 
-        if let Some(freq) = freq {
+        // freq being None indicates that TSC doesn't have a stable frequency and is not reliable for time keeping
+        if freq.is_some() {
             LearningFreqTscBuilder::new()
-                .set_initial_frequency(freq)
-                .set_frequency_learning_period(Duration::from_secs(120))
+                .set_frequency_learning_period(Duration::from_secs(30))
                 .set_max_acceptable_drift(Duration::from_millis(1))
-                .set_max_sync_interval(Duration::from_secs(60))
+                .set_max_sync_interval(Duration::from_secs(30))
                 .set_monotonic_time()
                 .build()
         } else {


### PR DESCRIPTION
The updated insecure-time fixes a few issues related to time drift.

`insecure-time` PR: https://github.com/fortanix/rust-sgx/pull/924 